### PR TITLE
feat: Add dashboard page stats integration with offline drift database

### DIFF
--- a/lib/common/utils/transaction_type_icon.dart
+++ b/lib/common/utils/transaction_type_icon.dart
@@ -1,0 +1,17 @@
+enum TransactionTypeIcon {
+  card('card'),
+  coinsBag('coins_bag'),
+  stockChart('stock_chart'),
+  dollarSign('dollar_sign'),
+  officeBriefcase('briefcase'),
+  forkKnife('fork_knife'),
+  cart('cart'),
+  watchTv('watch_tv'),
+  electricity('electricity'),
+  fuelPump('fuel_pump'),
+  chartIncreasing('chart_increasing');
+
+  final String value;
+
+  const TransactionTypeIcon(this.value);
+}

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -1,0 +1,21 @@
+import 'package:drift/drift.dart';
+
+import 'tables/tables.dart';
+
+part 'app_database.g.dart';
+
+@DriftDatabase(tables: [WalletTable, TransactionTable, SpendingChartTable])
+class AppDatabase extends _$AppDatabase {
+  AppDatabase(super.e);
+
+  @override
+  int get schemaVersion => 1;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+    onCreate: (Migrator migrator) async => await migrator.createAll(),
+    onUpgrade: (Migrator m, int from, int to) async {
+      // Handle future migrations here
+    },
+  );
+}

--- a/lib/core/database/database_client.dart
+++ b/lib/core/database/database_client.dart
@@ -1,0 +1,87 @@
+import 'dart:developer';
+
+import 'package:dartz/dartz.dart';
+import 'package:extro/core/database/i_database_client.dart';
+import 'package:extro/core/failures/failure.dart';
+import 'package:injectable/injectable.dart';
+
+import 'app_database.dart';
+
+@Singleton(as: IDatabaseClient)
+class DatabaseClient implements IDatabaseClient {
+  final AppDatabase _database;
+
+  DatabaseClient({required AppDatabase database}) : _database = database;
+
+  AppDatabase get database => _database;
+
+  @override
+  Future<Either<Failure, List<T>>> getAll<T>(
+    Future<List<T>> Function() query,
+  ) async {
+    try {
+      final result = await query();
+      return Right(result);
+    } catch (e, stackTrace) {
+      log('Database getAll error', error: e, stackTrace: stackTrace);
+      return Left(Failure.cache(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, T?>> getOne<T>(Future<T?> Function() query) async {
+    try {
+      final result = await query();
+      return Right(result);
+    } catch (e, stackTrace) {
+      log('Database getOne error', error: e, stackTrace: stackTrace);
+      return Left(Failure.cache(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, int>> insert<T>(Future<int> Function() query) async {
+    try {
+      final result = await query();
+      return Right(result);
+    } catch (e, stackTrace) {
+      log('Database insert error', error: e, stackTrace: stackTrace);
+      return Left(Failure.cache(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> update(Future<bool> Function() query) async {
+    try {
+      final result = await query();
+      return Right(result);
+    } catch (e, stackTrace) {
+      log('Database update error', error: e, stackTrace: stackTrace);
+      return Left(Failure.cache(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, int>> delete(Future<int> Function() query) async {
+    try {
+      final result = await query();
+      return Right(result);
+    } catch (e, stackTrace) {
+      log('Database delete error', error: e, stackTrace: stackTrace);
+      return Left(Failure.cache(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> batch(
+    Future<void> Function() operations,
+  ) async {
+    try {
+      await operations();
+      return const Right(null);
+    } catch (e, stackTrace) {
+      log('Database batch error', error: e, stackTrace: stackTrace);
+      return Left(Failure.cache(message: e.toString()));
+    }
+  }
+}

--- a/lib/core/database/database_connection.dart
+++ b/lib/core/database/database_connection.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'app_database.dart';
+
+const String _databaseName = 'extro_database.sqlite';
+
+Future<AppDatabase> createDatabase() async {
+  return AppDatabase(_openConnection());
+}
+
+LazyDatabase _openConnection() {
+  return LazyDatabase(() async {
+    final dbFolder = await getApplicationDocumentsDirectory();
+    final file = File(p.join(dbFolder.path, _databaseName));
+    return NativeDatabase.createInBackground(file);
+  });
+}

--- a/lib/core/database/database_seeder.dart
+++ b/lib/core/database/database_seeder.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:drift/drift.dart';
+import 'package:extro/common/utils/transaction_type_icon.dart';
 import 'package:extro/core/database/app_database.dart';
 
 class DatabaseSeeder {
@@ -10,7 +11,7 @@ class DatabaseSeeder {
 
   Future<void> seedInitialData() async {
     final walletCount = await _countWallets();
-    
+
     if (walletCount == 0) {
       await _seedWallets();
       await _seedTransactions();
@@ -32,21 +33,21 @@ class DatabaseSeeder {
           label: 'Main Wallet',
           balance: 15000.0,
           currency: 'USD',
-          icon: '💳',
+          icon: TransactionTypeIcon.card.value,
           accentColor: '#4A90E2',
         ),
         WalletTableCompanion.insert(
           label: 'Savings',
           balance: 8500.0,
           currency: 'USD',
-          icon: '💰',
+          icon: TransactionTypeIcon.coinsBag.value,
           accentColor: '#50C878',
         ),
         WalletTableCompanion.insert(
           label: 'Investment',
           balance: 12300.0,
           currency: 'USD',
-          icon: '📈',
+          icon: TransactionTypeIcon.stockChart.value,
           accentColor: '#FF6B6B',
         ),
       ]);
@@ -61,7 +62,7 @@ class DatabaseSeeder {
           transactionDateTime: DateTime(2025, 12, 20, 9),
           amount: 3500.00,
           isIncome: true,
-          icon: '💵',
+          icon: TransactionTypeIcon.dollarSign.value,
           walletId: 1,
         ),
         TransactionTableCompanion.insert(
@@ -69,7 +70,7 @@ class DatabaseSeeder {
           transactionDateTime: DateTime(2025, 12, 22, 14, 30),
           amount: 1200.00,
           isIncome: true,
-          icon: '💼',
+          icon: TransactionTypeIcon.officeBriefcase.value,
           walletId: 1,
         ),
         TransactionTableCompanion.insert(
@@ -77,7 +78,7 @@ class DatabaseSeeder {
           transactionDateTime: DateTime(2025, 12, 24, 10, 30),
           amount: -85.50,
           isIncome: false,
-          icon: '🛒',
+          icon: TransactionTypeIcon.cart.value,
           walletId: 1,
         ),
         TransactionTableCompanion.insert(
@@ -85,7 +86,7 @@ class DatabaseSeeder {
           transactionDateTime: DateTime(2025, 12, 23, 19),
           amount: -45.00,
           isIncome: false,
-          icon: '🍽️',
+          icon: TransactionTypeIcon.forkKnife.value,
           walletId: 1,
         ),
         TransactionTableCompanion.insert(
@@ -93,7 +94,7 @@ class DatabaseSeeder {
           transactionDateTime: DateTime(2025, 12, 15, 12),
           amount: -15.99,
           isIncome: false,
-          icon: '🎬',
+          icon: TransactionTypeIcon.watchTv.value,
           walletId: 1,
         ),
         TransactionTableCompanion.insert(
@@ -101,7 +102,7 @@ class DatabaseSeeder {
           transactionDateTime: DateTime(2025, 12, 18, 8),
           amount: -120.00,
           isIncome: false,
-          icon: '⚡',
+          icon: TransactionTypeIcon.electricity.value,
           walletId: 1,
         ),
         TransactionTableCompanion.insert(
@@ -109,7 +110,7 @@ class DatabaseSeeder {
           transactionDateTime: DateTime(2025, 12, 21, 16, 30),
           amount: -60.00,
           isIncome: false,
-          icon: '⛽',
+          icon: TransactionTypeIcon.fuelPump.value,
           walletId: 1,
         ),
         TransactionTableCompanion.insert(
@@ -117,7 +118,7 @@ class DatabaseSeeder {
           transactionDateTime: DateTime(2025, 12, 25, 10),
           amount: 850.00,
           isIncome: true,
-          icon: '📊',
+          icon: TransactionTypeIcon.chartIncreasing.value,
           walletId: 3,
         ),
       ]);
@@ -126,8 +127,10 @@ class DatabaseSeeder {
 
   Future<void> _seedSpendingChart() async {
     final spendingData = [120.0, 85.0, 150.0, 95.0, 200.0, 175.0, 110.0];
-    
-    await _database.into(_database.spendingChartTable).insert(
+
+    await _database
+        .into(_database.spendingChartTable)
+        .insert(
           SpendingChartTableCompanion.insert(
             spendingData: jsonEncode(spendingData),
             totalAmount: '935.00',

--- a/lib/core/database/database_seeder.dart
+++ b/lib/core/database/database_seeder.dart
@@ -1,0 +1,138 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+import 'package:extro/core/database/app_database.dart';
+
+class DatabaseSeeder {
+  final AppDatabase _database;
+
+  DatabaseSeeder(this._database);
+
+  Future<void> seedInitialData() async {
+    final walletCount = await _countWallets();
+    
+    if (walletCount == 0) {
+      await _seedWallets();
+      await _seedTransactions();
+      await _seedSpendingChart();
+    }
+  }
+
+  Future<int> _countWallets() async {
+    final query = _database.selectOnly(_database.walletTable)
+      ..addColumns([_database.walletTable.id.count()]);
+    final result = await query.getSingle();
+    return result.read(_database.walletTable.id.count()) ?? 0;
+  }
+
+  Future<void> _seedWallets() async {
+    await _database.batch((batch) {
+      batch.insertAll(_database.walletTable, [
+        WalletTableCompanion.insert(
+          label: 'Main Wallet',
+          balance: 15000.0,
+          currency: 'USD',
+          icon: '💳',
+          accentColor: '#4A90E2',
+        ),
+        WalletTableCompanion.insert(
+          label: 'Savings',
+          balance: 8500.0,
+          currency: 'USD',
+          icon: '💰',
+          accentColor: '#50C878',
+        ),
+        WalletTableCompanion.insert(
+          label: 'Investment',
+          balance: 12300.0,
+          currency: 'USD',
+          icon: '📈',
+          accentColor: '#FF6B6B',
+        ),
+      ]);
+    });
+  }
+
+  Future<void> _seedTransactions() async {
+    await _database.batch((batch) {
+      batch.insertAll(_database.transactionTable, [
+        TransactionTableCompanion.insert(
+          title: 'Salary',
+          transactionDateTime: DateTime(2025, 12, 20, 9),
+          amount: 3500.00,
+          isIncome: true,
+          icon: '💵',
+          walletId: 1,
+        ),
+        TransactionTableCompanion.insert(
+          title: 'Freelance Project',
+          transactionDateTime: DateTime(2025, 12, 22, 14, 30),
+          amount: 1200.00,
+          isIncome: true,
+          icon: '💼',
+          walletId: 1,
+        ),
+        TransactionTableCompanion.insert(
+          title: 'Grocery Shopping',
+          transactionDateTime: DateTime(2025, 12, 24, 10, 30),
+          amount: -85.50,
+          isIncome: false,
+          icon: '🛒',
+          walletId: 1,
+        ),
+        TransactionTableCompanion.insert(
+          title: 'Restaurant',
+          transactionDateTime: DateTime(2025, 12, 23, 19),
+          amount: -45.00,
+          isIncome: false,
+          icon: '🍽️',
+          walletId: 1,
+        ),
+        TransactionTableCompanion.insert(
+          title: 'Netflix Subscription',
+          transactionDateTime: DateTime(2025, 12, 15, 12),
+          amount: -15.99,
+          isIncome: false,
+          icon: '🎬',
+          walletId: 1,
+        ),
+        TransactionTableCompanion.insert(
+          title: 'Electricity Bill',
+          transactionDateTime: DateTime(2025, 12, 18, 8),
+          amount: -120.00,
+          isIncome: false,
+          icon: '⚡',
+          walletId: 1,
+        ),
+        TransactionTableCompanion.insert(
+          title: 'Gas Station',
+          transactionDateTime: DateTime(2025, 12, 21, 16, 30),
+          amount: -60.00,
+          isIncome: false,
+          icon: '⛽',
+          walletId: 1,
+        ),
+        TransactionTableCompanion.insert(
+          title: 'Investment Return',
+          transactionDateTime: DateTime(2025, 12, 25, 10),
+          amount: 850.00,
+          isIncome: true,
+          icon: '📊',
+          walletId: 3,
+        ),
+      ]);
+    });
+  }
+
+  Future<void> _seedSpendingChart() async {
+    final spendingData = [120.0, 85.0, 150.0, 95.0, 200.0, 175.0, 110.0];
+    
+    await _database.into(_database.spendingChartTable).insert(
+          SpendingChartTableCompanion.insert(
+            spendingData: jsonEncode(spendingData),
+            totalAmount: '935.00',
+            percentageChange: '+12.5',
+          ),
+        );
+  }
+}

--- a/lib/core/database/i_database_client.dart
+++ b/lib/core/database/i_database_client.dart
@@ -2,27 +2,15 @@ import 'package:dartz/dartz.dart';
 import 'package:extro/core/failures/failure.dart';
 
 abstract interface class IDatabaseClient {
-  Future<Either<Failure, List<T>>> getAll<T>(
-    Future<List<T>> Function() query,
-  );
+  Future<Either<Failure, List<T>>> getAll<T>(Future<List<T>> Function() query);
 
-  Future<Either<Failure, T?>> getOne<T>(
-    Future<T?> Function() query,
-  );
+  Future<Either<Failure, T?>> getOne<T>(Future<T?> Function() query);
 
-  Future<Either<Failure, int>> insert<T>(
-    Future<int> Function() query,
-  );
+  Future<Either<Failure, int>> insert<T>(Future<int> Function() query);
 
-  Future<Either<Failure, bool>> update(
-    Future<bool> Function() query,
-  );
+  Future<Either<Failure, bool>> update(Future<bool> Function() query);
 
-  Future<Either<Failure, int>> delete(
-    Future<int> Function() query,
-  );
+  Future<Either<Failure, int>> delete(Future<int> Function() query);
 
-  Future<Either<Failure, void>> batch(
-    Future<void> Function() operations,
-  );
+  Future<Either<Failure, void>> batch(Future<void> Function() operations);
 }

--- a/lib/core/database/i_database_client.dart
+++ b/lib/core/database/i_database_client.dart
@@ -1,0 +1,28 @@
+import 'package:dartz/dartz.dart';
+import 'package:extro/core/failures/failure.dart';
+
+abstract interface class IDatabaseClient {
+  Future<Either<Failure, List<T>>> getAll<T>(
+    Future<List<T>> Function() query,
+  );
+
+  Future<Either<Failure, T?>> getOne<T>(
+    Future<T?> Function() query,
+  );
+
+  Future<Either<Failure, int>> insert<T>(
+    Future<int> Function() query,
+  );
+
+  Future<Either<Failure, bool>> update(
+    Future<bool> Function() query,
+  );
+
+  Future<Either<Failure, int>> delete(
+    Future<int> Function() query,
+  );
+
+  Future<Either<Failure, void>> batch(
+    Future<void> Function() operations,
+  );
+}

--- a/lib/core/database/tables/spending_chart_table.dart
+++ b/lib/core/database/tables/spending_chart_table.dart
@@ -1,0 +1,8 @@
+import 'package:drift/drift.dart';
+
+class SpendingChartTable extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get spendingData => text()();
+  TextColumn get totalAmount => text()();
+  TextColumn get percentageChange => text()();
+}

--- a/lib/core/database/tables/tables.dart
+++ b/lib/core/database/tables/tables.dart
@@ -1,0 +1,3 @@
+export 'wallet_table.dart';
+export 'transaction_table.dart';
+export 'spending_chart_table.dart';

--- a/lib/core/database/tables/transaction_table.dart
+++ b/lib/core/database/tables/transaction_table.dart
@@ -1,0 +1,12 @@
+import 'package:drift/drift.dart';
+
+@DataClassName('TransactionTableData')
+class TransactionTable extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get title => text()();
+  DateTimeColumn get transactionDateTime => dateTime()();
+  RealColumn get amount => real()();
+  BoolColumn get isIncome => boolean()();
+  TextColumn get icon => text()();
+  IntColumn get walletId => integer()();
+}

--- a/lib/core/database/tables/wallet_table.dart
+++ b/lib/core/database/tables/wallet_table.dart
@@ -1,0 +1,10 @@
+import 'package:drift/drift.dart';
+
+class WalletTable extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get label => text()();
+  RealColumn get balance => real()();
+  TextColumn get currency => text()();
+  TextColumn get icon => text()();
+  TextColumn get accentColor => text()();
+}

--- a/lib/core/di/register_module.dart
+++ b/lib/core/di/register_module.dart
@@ -3,6 +3,9 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:injectable/injectable.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../database/app_database.dart';
+import '../database/database_connection.dart';
+
 @module
 abstract class RegisterModule {
   @lazySingleton
@@ -18,4 +21,7 @@ abstract class RegisterModule {
           allowList: <String>{'theme_mode'},
         ),
       );
+
+  @preResolve
+  Future<AppDatabase> get appDatabase => createDatabase();
 }

--- a/lib/features/dashboard/data/data_sources/dashboard_local_data_source.dart
+++ b/lib/features/dashboard/data/data_sources/dashboard_local_data_source.dart
@@ -1,75 +1,104 @@
+import 'package:drift/drift.dart';
+import 'package:extro/core/database/app_database.dart';
+import 'package:extro/core/database/database_seeder.dart';
 import 'package:injectable/injectable.dart';
 
-import '../models/spending_chart_response.dart';
-import '../models/transaction_response.dart';
-import '../models/wallet_response.dart';
 import 'i_dashboard_local_data_source.dart';
 
 @Singleton(as: IDashboardLocalDataSource)
 class DashboardLocalDataSource implements IDashboardLocalDataSource {
-  DashboardLocalDataSource();
+  final AppDatabase _database;
+  late final DatabaseSeeder _seeder;
 
-  @override
-  Future<List<WalletResponse>> getAllWallets() async {
-    return [
-      const WalletResponse(
-        id: 1,
-        label: 'Main Wallet',
-        balance: 15000.0,
-        currency: 'USD',
-        icon: '💳',
-        accentColor: '#4A90E2',
-      ),
-      const WalletResponse(
-        id: 2,
-        label: 'Savings',
-        balance: 8500.0,
-        currency: 'USD',
-        icon: '💰',
-        accentColor: '#50C878',
-      ),
-    ];
+  DashboardLocalDataSource({required AppDatabase database})
+      : _database = database {
+    _seeder = DatabaseSeeder(_database);
   }
 
   @override
-  Future<List<TransactionResponse>> getRecentTransactions() async {
-    return [
-      const TransactionResponse(
-        id: 1,
-        title: 'Grocery Shopping',
-        dateTime: '2025-12-24T10:30:00Z',
-        amount: -85.50,
-        isIncome: false,
-        icon: '🛒',
-        walletId: 1,
-      ),
-      const TransactionResponse(
-        id: 2,
-        title: 'Salary',
-        dateTime: '2025-12-20T09:00:00Z',
-        amount: 3500.00,
-        isIncome: true,
-        icon: '💵',
-        walletId: 1,
-      ),
-      const TransactionResponse(
-        id: 3,
-        title: 'Netflix Subscription',
-        dateTime: '2025-12-15T12:00:00Z',
-        amount: -15.99,
-        isIncome: false,
-        icon: '🎬',
-        walletId: 1,
-      ),
-    ];
+  Future<void> seedInitialData() async {
+    await _seeder.seedInitialData();
   }
 
   @override
-  Future<SpendingChartResponse> getWeeklySpendingChart() async {
-    return const SpendingChartResponse(
-      spendingData: [120.0, 85.0, 150.0, 95.0, 200.0, 175.0, 110.0],
-      totalAmount: '935.00',
-      percentageChange: '+12.5',
-    );
+  Future<List<WalletTableData>> getAllWallets() async {
+    await seedInitialData();
+    return _database.select(_database.walletTable).get();
+  }
+
+  @override
+  Future<List<TransactionTableData>> getRecentTransactions() async {
+    await seedInitialData();
+    return (_database.select(_database.transactionTable)
+          ..orderBy([
+            (t) => OrderingTerm(
+                  expression: t.transactionDateTime,
+                  mode: OrderingMode.desc,
+                ),
+          ])
+          ..limit(10))
+        .get();
+  }
+
+  @override
+  Future<SpendingChartTableData?> getWeeklySpendingChart() async {
+    await seedInitialData();
+    return (_database.select(_database.spendingChartTable)..limit(1))
+        .getSingleOrNull();
+  }
+
+  @override
+  Future<double> getTotalIncome() async {
+    await seedInitialData();
+    final query = _database.selectOnly(_database.transactionTable)
+      ..addColumns([_database.transactionTable.amount.sum()])
+      ..where(_database.transactionTable.isIncome.equals(true));
+    
+    final result = await query.getSingle();
+    return result.read(_database.transactionTable.amount.sum()) ?? 0.0;
+  }
+
+  @override
+  Future<double> getTotalExpenses() async {
+    await seedInitialData();
+    final query = _database.selectOnly(_database.transactionTable)
+      ..addColumns([_database.transactionTable.amount.sum()])
+      ..where(_database.transactionTable.isIncome.equals(false));
+    
+    final result = await query.getSingle();
+    final sum = result.read(_database.transactionTable.amount.sum()) ?? 0.0;
+    return sum.abs();
+  }
+
+  @override
+  Future<void> insertWallet(WalletTableCompanion wallet) async {
+    await _database.into(_database.walletTable).insert(wallet);
+  }
+
+  @override
+  Future<void> insertTransaction(TransactionTableCompanion transaction) async {
+    await _database.into(_database.transactionTable).insert(transaction);
+  }
+
+  @override
+  Future<void> saveSpendingChart(SpendingChartTableCompanion chart) async {
+    await _database.delete(_database.spendingChartTable).go();
+    await _database.into(_database.spendingChartTable).insert(chart);
+  }
+
+  @override
+  Future<void> insertWallets(List<WalletTableCompanion> wallets) async {
+    await _database.batch((batch) {
+      batch.insertAll(_database.walletTable, wallets);
+    });
+  }
+
+  @override
+  Future<void> insertTransactions(
+    List<TransactionTableCompanion> transactions,
+  ) async {
+    await _database.batch((batch) {
+      batch.insertAll(_database.transactionTable, transactions);
+    });
   }
 }

--- a/lib/features/dashboard/data/data_sources/dashboard_local_data_source.dart
+++ b/lib/features/dashboard/data/data_sources/dashboard_local_data_source.dart
@@ -11,7 +11,7 @@ class DashboardLocalDataSource implements IDashboardLocalDataSource {
   late final DatabaseSeeder _seeder;
 
   DashboardLocalDataSource({required AppDatabase database})
-      : _database = database {
+    : _database = database {
     _seeder = DatabaseSeeder(_database);
   }
 
@@ -32,9 +32,9 @@ class DashboardLocalDataSource implements IDashboardLocalDataSource {
     return (_database.select(_database.transactionTable)
           ..orderBy([
             (t) => OrderingTerm(
-                  expression: t.transactionDateTime,
-                  mode: OrderingMode.desc,
-                ),
+              expression: t.transactionDateTime,
+              mode: OrderingMode.desc,
+            ),
           ])
           ..limit(10))
         .get();
@@ -43,8 +43,9 @@ class DashboardLocalDataSource implements IDashboardLocalDataSource {
   @override
   Future<SpendingChartTableData?> getWeeklySpendingChart() async {
     await seedInitialData();
-    return (_database.select(_database.spendingChartTable)..limit(1))
-        .getSingleOrNull();
+    return (_database.select(
+      _database.spendingChartTable,
+    )..limit(1)).getSingleOrNull();
   }
 
   @override
@@ -53,7 +54,7 @@ class DashboardLocalDataSource implements IDashboardLocalDataSource {
     final query = _database.selectOnly(_database.transactionTable)
       ..addColumns([_database.transactionTable.amount.sum()])
       ..where(_database.transactionTable.isIncome.equals(true));
-    
+
     final result = await query.getSingle();
     return result.read(_database.transactionTable.amount.sum()) ?? 0.0;
   }
@@ -64,7 +65,7 @@ class DashboardLocalDataSource implements IDashboardLocalDataSource {
     final query = _database.selectOnly(_database.transactionTable)
       ..addColumns([_database.transactionTable.amount.sum()])
       ..where(_database.transactionTable.isIncome.equals(false));
-    
+
     final result = await query.getSingle();
     final sum = result.read(_database.transactionTable.amount.sum()) ?? 0.0;
     return sum.abs();

--- a/lib/features/dashboard/data/data_sources/i_dashboard_local_data_source.dart
+++ b/lib/features/dashboard/data/data_sources/i_dashboard_local_data_source.dart
@@ -1,9 +1,18 @@
-import '../models/wallet_response.dart';
-import '../models/transaction_response.dart';
-import '../models/spending_chart_response.dart';
+import 'package:extro/core/database/app_database.dart';
 
 abstract class IDashboardLocalDataSource {
-  Future<List<WalletResponse>> getAllWallets();
-  Future<List<TransactionResponse>> getRecentTransactions();
-  Future<SpendingChartResponse> getWeeklySpendingChart();
+  Future<List<WalletTableData>> getAllWallets();
+  Future<List<TransactionTableData>> getRecentTransactions();
+  Future<SpendingChartTableData?> getWeeklySpendingChart();
+
+  Future<void> insertWallet(WalletTableCompanion wallet);
+  Future<void> insertTransaction(TransactionTableCompanion transaction);
+  Future<void> saveSpendingChart(SpendingChartTableCompanion chart);
+
+  Future<void> insertWallets(List<WalletTableCompanion> wallets);
+  Future<void> insertTransactions(List<TransactionTableCompanion> transactions);
+
+  Future<double> getTotalIncome();
+  Future<double> getTotalExpenses();
+  Future<void> seedInitialData();
 }

--- a/lib/features/dashboard/data/mappers/table_data_mappers.dart
+++ b/lib/features/dashboard/data/mappers/table_data_mappers.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+import 'package:extro/core/database/app_database.dart';
+
+import '../../domain/entities/spending_chart.dart';
+import '../../domain/entities/transaction.dart';
+import '../../domain/entities/wallet.dart';
+
+extension WalletTableDataMapper on WalletTableData {
+  Wallet toDomain() {
+    return Wallet(
+      id: id,
+      label: label,
+      balance: balance,
+      currency: currency,
+      icon: icon,
+      accentColor: accentColor,
+    );
+  }
+}
+
+extension TransactionTableDataMapper on TransactionTableData {
+  Transaction toDomain() {
+    return Transaction(
+      id: id,
+      title: title,
+      dateTime: transactionDateTime,
+      amount: amount,
+      isIncome: isIncome,
+      icon: icon,
+      walletId: walletId,
+    );
+  }
+}
+
+extension SpendingChartTableDataMapper on SpendingChartTableData {
+  SpendingChart toDomain() {
+    final List<double> parsedData = (jsonDecode(spendingData) as List)
+        .map((e) => (e as num).toDouble())
+        .toList();
+    return SpendingChart(
+      spendingData: parsedData,
+      totalAmount: totalAmount,
+      percentageChange: percentageChange,
+    );
+  }
+}

--- a/lib/features/dashboard/data/repositories/dashboard_stats_repository.dart
+++ b/lib/features/dashboard/data/repositories/dashboard_stats_repository.dart
@@ -17,12 +17,12 @@ class DashboardStatsRepository implements IDashboardStatsRepository {
     try {
       final income = await localDataSource.getTotalIncome();
       final expenses = await localDataSource.getTotalExpenses();
-      
+
       final stats = DashboardStats(
         totalIncome: income,
         totalExpenses: expenses,
       );
-      
+
       return Right(stats);
     } catch (e) {
       return const Left(Failure.cache());

--- a/lib/features/dashboard/data/repositories/dashboard_stats_repository.dart
+++ b/lib/features/dashboard/data/repositories/dashboard_stats_repository.dart
@@ -1,0 +1,31 @@
+import 'package:dartz/dartz.dart';
+import 'package:extro/core/failures/failure.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../domain/entities/dashboard_stats.dart';
+import '../../domain/repositories/i_dashboard_stats_repository.dart';
+import '../data_sources/i_dashboard_local_data_source.dart';
+
+@Singleton(as: IDashboardStatsRepository)
+class DashboardStatsRepository implements IDashboardStatsRepository {
+  final IDashboardLocalDataSource localDataSource;
+
+  DashboardStatsRepository({required this.localDataSource});
+
+  @override
+  Future<Either<Failure, DashboardStats>> getDashboardStats() async {
+    try {
+      final income = await localDataSource.getTotalIncome();
+      final expenses = await localDataSource.getTotalExpenses();
+      
+      final stats = DashboardStats(
+        totalIncome: income,
+        totalExpenses: expenses,
+      );
+      
+      return Right(stats);
+    } catch (e) {
+      return const Left(Failure.cache());
+    }
+  }
+}

--- a/lib/features/dashboard/data/repositories/spending_chart_repository.dart
+++ b/lib/features/dashboard/data/repositories/spending_chart_repository.dart
@@ -5,6 +5,7 @@ import 'package:injectable/injectable.dart';
 import '../../domain/entities/spending_chart.dart';
 import '../../domain/repositories/i_spending_chart_repository.dart';
 import '../data_sources/i_dashboard_local_data_source.dart';
+import '../mappers/table_data_mappers.dart';
 
 @Singleton(as: ISpendingChartRepository)
 class SpendingChartRepository implements ISpendingChartRepository {
@@ -15,15 +16,17 @@ class SpendingChartRepository implements ISpendingChartRepository {
   @override
   Future<Either<Failure, SpendingChart>> getWeeklySpendingChart() async {
     try {
-      final response = await localDataSource.getWeeklySpendingChart();
-      final chart = SpendingChart(
-        spendingData: response.spendingData,
-        totalAmount: response.totalAmount,
-        percentageChange: response.percentageChange,
-      );
-      return Right(chart);
+      final tableData = await localDataSource.getWeeklySpendingChart();
+      if (tableData == null) {
+        return const Right(SpendingChart(
+          spendingData: [],
+          totalAmount: '0.00',
+          percentageChange: '0.0',
+        ));
+      }
+      return Right(tableData.toDomain());
     } catch (e) {
-      return const Left(Failure.dataProcessing());
+      return const Left(Failure.cache());
     }
   }
 }

--- a/lib/features/dashboard/data/repositories/spending_chart_repository.dart
+++ b/lib/features/dashboard/data/repositories/spending_chart_repository.dart
@@ -18,11 +18,13 @@ class SpendingChartRepository implements ISpendingChartRepository {
     try {
       final tableData = await localDataSource.getWeeklySpendingChart();
       if (tableData == null) {
-        return const Right(SpendingChart(
-          spendingData: [],
-          totalAmount: '0.00',
-          percentageChange: '0.0',
-        ));
+        return const Right(
+          SpendingChart(
+            spendingData: [],
+            totalAmount: '0.00',
+            percentageChange: '0.0',
+          ),
+        );
       }
       return Right(tableData.toDomain());
     } catch (e) {

--- a/lib/features/dashboard/data/repositories/transaction_repository.dart
+++ b/lib/features/dashboard/data/repositories/transaction_repository.dart
@@ -5,6 +5,7 @@ import 'package:injectable/injectable.dart';
 import '../../domain/entities/transaction.dart';
 import '../../domain/repositories/i_transaction_repository.dart';
 import '../data_sources/i_dashboard_local_data_source.dart';
+import '../mappers/table_data_mappers.dart';
 
 @Singleton(as: ITransactionRepository)
 class TransactionRepository implements ITransactionRepository {
@@ -15,23 +16,11 @@ class TransactionRepository implements ITransactionRepository {
   @override
   Future<Either<Failure, List<Transaction>>> getRecentTransactions() async {
     try {
-      final responses = await localDataSource.getRecentTransactions();
-      final transactions = responses
-          .map(
-            (e) => Transaction(
-              id: e.id,
-              title: e.title,
-              dateTime: DateTime.parse(e.dateTime),
-              amount: e.amount,
-              isIncome: e.isIncome,
-              icon: e.icon,
-              walletId: e.walletId,
-            ),
-          )
-          .toList();
+      final tableData = await localDataSource.getRecentTransactions();
+      final transactions = tableData.map((e) => e.toDomain()).toList();
       return Right(transactions);
     } catch (e) {
-      return const Left(Failure.dataProcessing());
+      return const Left(Failure.cache());
     }
   }
 }

--- a/lib/features/dashboard/data/repositories/wallet_repository.dart
+++ b/lib/features/dashboard/data/repositories/wallet_repository.dart
@@ -5,6 +5,7 @@ import 'package:injectable/injectable.dart';
 import '../../domain/entities/wallet.dart';
 import '../../domain/repositories/i_wallet_repository.dart';
 import '../data_sources/i_dashboard_local_data_source.dart';
+import '../mappers/table_data_mappers.dart';
 
 @Singleton(as: IWalletRepository)
 class WalletRepository implements IWalletRepository {
@@ -15,22 +16,11 @@ class WalletRepository implements IWalletRepository {
   @override
   Future<Either<Failure, List<Wallet>>> getAllWallets() async {
     try {
-      final responses = await localDataSource.getAllWallets();
-      final wallets = responses
-          .map(
-            (e) => Wallet(
-              id: e.id,
-              label: e.label,
-              balance: e.balance,
-              currency: e.currency,
-              icon: e.icon,
-              accentColor: e.accentColor,
-            ),
-          )
-          .toList();
+      final tableData = await localDataSource.getAllWallets();
+      final wallets = tableData.map((e) => e.toDomain()).toList();
       return Right(wallets);
     } catch (e) {
-      return const Left(Failure.dataProcessing());
+      return const Left(Failure.cache());
     }
   }
 }

--- a/lib/features/dashboard/domain/cubits/dashboard_stats_cubit/dashboard_stats_cubit.dart
+++ b/lib/features/dashboard/domain/cubits/dashboard_stats_cubit/dashboard_stats_cubit.dart
@@ -26,4 +26,3 @@ class DashboardStatsCubit extends Cubit<DashboardStatsState> {
     );
   }
 }
-

--- a/lib/features/dashboard/domain/cubits/dashboard_stats_cubit/dashboard_stats_cubit.dart
+++ b/lib/features/dashboard/domain/cubits/dashboard_stats_cubit/dashboard_stats_cubit.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../../core/di/locator.dart';
+import '../../../../../core/failures/failure.dart';
+import '../../entities/dashboard_stats.dart';
+import '../../repositories/i_dashboard_stats_repository.dart';
+
+part 'dashboard_stats_cubit.freezed.dart';
+part 'dashboard_stats_state.dart';
+
+class DashboardStatsCubit extends Cubit<DashboardStatsState> {
+  DashboardStatsCubit({IDashboardStatsRepository? repository})
+    : _repository = repository ?? locator<IDashboardStatsRepository>(),
+      super(const DashboardStatsState.initial());
+
+  final IDashboardStatsRepository _repository;
+
+  Future<void> fetchDashboardStats() async {
+    emit(const DashboardStatsState.loading());
+    final result = await _repository.getDashboardStats();
+    if (isClosed) return;
+    result.fold(
+      (failure) => emit(DashboardStatsState.failure(failure)),
+      (stats) => emit(DashboardStatsState.success(stats)),
+    );
+  }
+}
+

--- a/lib/features/dashboard/domain/cubits/dashboard_stats_cubit/dashboard_stats_state.dart
+++ b/lib/features/dashboard/domain/cubits/dashboard_stats_cubit/dashboard_stats_state.dart
@@ -1,0 +1,9 @@
+part of 'dashboard_stats_cubit.dart';
+
+@freezed
+sealed class DashboardStatsState with _$DashboardStatsState {
+  const factory DashboardStatsState.initial() = _Initial;
+  const factory DashboardStatsState.loading() = _Loading;
+  const factory DashboardStatsState.success(DashboardStats stats) = _Success;
+  const factory DashboardStatsState.failure(Failure failure) = _Failure;
+}

--- a/lib/features/dashboard/domain/entities/dashboard_stats.dart
+++ b/lib/features/dashboard/domain/entities/dashboard_stats.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'dashboard_stats.freezed.dart';
+
+@freezed
+sealed class DashboardStats with _$DashboardStats {
+  const factory DashboardStats({
+    required double totalIncome,
+    required double totalExpenses,
+  }) = _DashboardStats;
+}

--- a/lib/features/dashboard/domain/repositories/i_dashboard_stats_repository.dart
+++ b/lib/features/dashboard/domain/repositories/i_dashboard_stats_repository.dart
@@ -1,0 +1,7 @@
+import 'package:dartz/dartz.dart';
+import '../entities/dashboard_stats.dart';
+import 'package:extro/core/failures/failure.dart';
+
+abstract class IDashboardStatsRepository {
+  Future<Either<Failure, DashboardStats>> getDashboardStats();
+}

--- a/lib/features/dashboard/presentation/screens/dashboard_screen.dart
+++ b/lib/features/dashboard/presentation/screens/dashboard_screen.dart
@@ -136,7 +136,8 @@ class _DashboardScreenState extends State<DashboardScreen> {
                             Expanded(
                               child: StatsCard(
                                 label: context.localizer.income,
-                                value: '+\$${stats.totalIncome.toStringAsFixed(2)}',
+                                value:
+                                    '+\$${stats.totalIncome.toStringAsFixed(2)}',
                                 isIncome: true,
                               ),
                             ),
@@ -144,7 +145,8 @@ class _DashboardScreenState extends State<DashboardScreen> {
                             Expanded(
                               child: StatsCard(
                                 label: context.localizer.expenses,
-                                value: '-\$${stats.totalExpenses.toStringAsFixed(2)}',
+                                value:
+                                    '-\$${stats.totalExpenses.toStringAsFixed(2)}',
                                 isIncome: false,
                               ),
                             ),

--- a/lib/features/dashboard/presentation/screens/dashboard_screen.dart
+++ b/lib/features/dashboard/presentation/screens/dashboard_screen.dart
@@ -11,6 +11,7 @@ import 'package:extro/features/dashboard/presentation/widgets/weekly_spending_ch
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../../domain/cubits/dashboard_stats_cubit/dashboard_stats_cubit.dart';
 import '../../domain/cubits/spending_chart_cubit/spending_chart_cubit.dart';
 import '../../domain/cubits/transaction_cubit/transaction_cubit.dart';
 import '../../domain/cubits/wallet_cubit/wallet_cubit.dart';
@@ -44,6 +45,9 @@ class _DashboardScreenState extends State<DashboardScreen> {
         ),
         BlocProvider<SpendingChartCubit>(
           create: (context) => SpendingChartCubit()..fetchWeeklySpendingChart(),
+        ),
+        BlocProvider<DashboardStatsCubit>(
+          create: (context) => DashboardStatsCubit()..fetchDashboardStats(),
         ),
       ],
       child: Scaffold(
@@ -124,15 +128,15 @@ class _DashboardScreenState extends State<DashboardScreen> {
                     },
                   ),
                   const SizedBox(height: 24),
-                  BlocBuilder<TransactionCubit, TransactionState>(
-                    builder: (context, transactionState) {
-                      return transactionState.maybeWhen(
-                        success: (transactions) => Row(
+                  BlocBuilder<DashboardStatsCubit, DashboardStatsState>(
+                    builder: (context, statsState) {
+                      return statsState.maybeWhen(
+                        success: (stats) => Row(
                           children: [
                             Expanded(
                               child: StatsCard(
                                 label: context.localizer.income,
-                                value: '+\$2,000',
+                                value: '+\$${stats.totalIncome.toStringAsFixed(2)}',
                                 isIncome: true,
                               ),
                             ),
@@ -140,7 +144,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
                             Expanded(
                               child: StatsCard(
                                 label: context.localizer.expenses,
-                                value: '-\$850',
+                                value: '-\$${stats.totalExpenses.toStringAsFixed(2)}',
                                 isIncome: false,
                               ),
                             ),
@@ -151,7 +155,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
                             Expanded(
                               child: StatsCard(
                                 label: context.localizer.income,
-                                value: '+\$0',
+                                value: '+\$0.00',
                                 isIncome: true,
                               ),
                             ),
@@ -159,7 +163,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
                             Expanded(
                               child: StatsCard(
                                 label: context.localizer.expenses,
-                                value: '-\$0',
+                                value: '-\$0.00',
                                 isIncome: false,
                               ),
                             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,12 @@ dependencies:
   auto_route: ^10.3.0
   shared_preferences: ^2.2.0
 
+  # Local Database
+  drift: ^2.14.0
+  sqlite3_flutter_libs: ^0.5.0
+  path_provider: ^2.0.0
+  path: ^1.8.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -53,6 +59,8 @@ dev_dependencies:
   freezed: ^3.2.3
   json_serializable: ^6.11.2
   injectable_generator: ^2.8.1
+  # Database code generation
+  drift_dev: ^2.14.0
   # Testing
   mocktail: ^1.0.4
   bloc_test: ^10.0.0

--- a/test/core/database/database_seeder_test.dart
+++ b/test/core/database/database_seeder_test.dart
@@ -1,0 +1,116 @@
+import 'package:drift/drift.dart';
+import 'package:extro/core/database/app_database.dart';
+import 'package:extro/core/database/database_seeder.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drift/native.dart';
+
+void main() {
+  group('DatabaseSeeder', () {
+    late AppDatabase database;
+    late DatabaseSeeder seeder;
+
+    setUp(() {
+      database = AppDatabase(NativeDatabase.memory());
+      seeder = DatabaseSeeder(database);
+    });
+
+    tearDown(() async {
+      await database.close();
+    });
+
+    group('seedInitialData', () {
+      test('seeds data when database is empty', () async {
+        await seeder.seedInitialData();
+
+        final wallets = await database.select(database.walletTable).get();
+        final transactions = await database
+            .select(database.transactionTable)
+            .get();
+        final spendingCharts = await database
+            .select(database.spendingChartTable)
+            .get();
+
+        expect(wallets.length, equals(3));
+        expect(transactions.length, equals(8));
+        expect(spendingCharts.length, equals(1));
+      });
+
+      test('does not seed data when database already has wallets', () async {
+        await database
+            .into(database.walletTable)
+            .insert(
+              WalletTableCompanion.insert(
+                label: 'Test Wallet',
+                balance: 100.0,
+                currency: 'USD',
+                icon: '💰',
+                accentColor: '#000000',
+              ),
+            );
+
+        await seeder.seedInitialData();
+
+        final wallets = await database.select(database.walletTable).get();
+        final transactions = await database
+            .select(database.transactionTable)
+            .get();
+
+        expect(wallets.length, equals(1));
+        expect(transactions.length, equals(0));
+      });
+
+      test('seeds correct wallet data', () async {
+        await seeder.seedInitialData();
+
+        final wallets = await database.select(database.walletTable).get();
+
+        expect(wallets[0].label, equals('Main Wallet'));
+        expect(wallets[0].balance, equals(15000.0));
+        expect(wallets[0].currency, equals('USD'));
+        expect(wallets[0].icon, equals('💳'));
+
+        expect(wallets[1].label, equals('Savings'));
+        expect(wallets[1].balance, equals(8500.0));
+
+        expect(wallets[2].label, equals('Investment'));
+        expect(wallets[2].balance, equals(12300.0));
+      });
+
+      test('seeds correct transaction data with income and expenses', () async {
+        await seeder.seedInitialData();
+
+        final transactions = await database
+            .select(database.transactionTable)
+            .get();
+
+        final incomeTransactions = transactions
+            .where((t) => t.isIncome)
+            .toList();
+        final expenseTransactions = transactions
+            .where((t) => !t.isIncome)
+            .toList();
+
+        expect(incomeTransactions.length, equals(3));
+        expect(expenseTransactions.length, equals(5));
+
+        expect(incomeTransactions[0].title, equals('Salary'));
+        expect(incomeTransactions[0].amount, equals(3500.00));
+
+        expect(expenseTransactions[0].title, equals('Grocery Shopping'));
+        expect(expenseTransactions[0].amount, equals(-85.50));
+      });
+
+      test('seeds spending chart data', () async {
+        await seeder.seedInitialData();
+
+        final spendingCharts = await database
+            .select(database.spendingChartTable)
+            .get();
+
+        expect(spendingCharts[0].totalAmount, equals('935.00'));
+        expect(spendingCharts[0].percentageChange, equals('+12.5'));
+        expect(spendingCharts[0].spendingData, isNotEmpty);
+      });
+    });
+  });
+}

--- a/test/core/database/database_seeder_test.dart
+++ b/test/core/database/database_seeder_test.dart
@@ -1,8 +1,8 @@
-import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:extro/common/utils/transaction_type_icon.dart';
 import 'package:extro/core/database/app_database.dart';
 import 'package:extro/core/database/database_seeder.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:drift/native.dart';
 
 void main() {
   group('DatabaseSeeder', () {
@@ -67,13 +67,17 @@ void main() {
         expect(wallets[0].label, equals('Main Wallet'));
         expect(wallets[0].balance, equals(15000.0));
         expect(wallets[0].currency, equals('USD'));
-        expect(wallets[0].icon, equals('💳'));
+        expect(wallets[0].icon, equals(TransactionTypeIcon.card.value));
 
         expect(wallets[1].label, equals('Savings'));
         expect(wallets[1].balance, equals(8500.0));
+        expect(wallets[1].currency, equals('USD'));
+        expect(wallets[1].icon, equals(TransactionTypeIcon.coinsBag.value));
 
         expect(wallets[2].label, equals('Investment'));
         expect(wallets[2].balance, equals(12300.0));
+        expect(wallets[2].currency, equals('USD'));
+        expect(wallets[2].icon, equals(TransactionTypeIcon.stockChart.value));
       });
 
       test('seeds correct transaction data with income and expenses', () async {

--- a/test/features/dashboard/data/data_sources/dashboard_local_data_source_test.dart
+++ b/test/features/dashboard/data/data_sources/dashboard_local_data_source_test.dart
@@ -1,0 +1,137 @@
+import 'package:drift/native.dart';
+import 'package:extro/core/database/app_database.dart';
+import 'package:extro/features/dashboard/data/data_sources/dashboard_local_data_source.dart';
+import 'package:flutter_test/flutter_test.dart' hide isNull, isNotNull;
+
+void main() {
+  group('DashboardLocalDataSource', () {
+    late AppDatabase database;
+    late DashboardLocalDataSource dataSource;
+
+    setUp(() async {
+      database = AppDatabase(NativeDatabase.memory());
+      dataSource = DashboardLocalDataSource(database: database);
+    });
+
+    tearDown(() async {
+      await database.close();
+    });
+
+    group('getAllWallets', () {
+      test('returns all wallets from database', () async {
+        final wallets = await dataSource.getAllWallets();
+
+        expect(wallets.length, greaterThanOrEqualTo(3));
+        expect(wallets.any((w) => w.label == 'Main Wallet'), isTrue);
+        expect(wallets.any((w) => w.label == 'Savings'), isTrue);
+        expect(wallets.any((w) => w.label == 'Investment'), isTrue);
+      });
+    });
+
+    group('getRecentTransactions', () {
+      test('returns transactions ordered by date descending', () async {
+        final transactions = await dataSource.getRecentTransactions();
+
+        expect(transactions, isNotEmpty);
+        for (int i = 0; i < transactions.length - 1; i++) {
+          expect(
+            transactions[i].transactionDateTime.isAfter(
+                  transactions[i + 1].transactionDateTime,
+                ) ||
+                transactions[i].transactionDateTime ==
+                    transactions[i + 1].transactionDateTime,
+            isTrue,
+          );
+        }
+      });
+
+      test('limits results to 10 transactions', () async {
+        final transactions = await dataSource.getRecentTransactions();
+
+        expect(transactions.length, lessThanOrEqualTo(10));
+      });
+    });
+
+    group('getWeeklySpendingChart', () {
+      test('returns spending chart when exists', () async {
+        final chart = await dataSource.getWeeklySpendingChart();
+
+        expect(chart, isA<SpendingChartTableData>());
+        expect(chart!.totalAmount, isNotEmpty);
+        expect(chart.percentageChange, isNotEmpty);
+        expect(chart.spendingData, isNotEmpty);
+      });
+    });
+
+    group('getTotalIncome', () {
+      test('calculates total income from income transactions', () async {
+        final totalIncome = await dataSource.getTotalIncome();
+
+        expect(totalIncome, greaterThanOrEqualTo(0.0));
+      });
+    });
+
+    group('getTotalExpenses', () {
+      test('calculates total expenses from expense transactions', () async {
+        final totalExpenses = await dataSource.getTotalExpenses();
+
+        expect(totalExpenses, greaterThanOrEqualTo(0.0));
+      });
+    });
+
+    group('insertWallet', () {
+      test('inserts wallet into database', () async {
+        await dataSource.insertWallet(
+          WalletTableCompanion.insert(
+            label: 'New Wallet',
+            balance: 500.0,
+            currency: 'USD',
+            icon: '💳',
+            accentColor: '#FF0000',
+          ),
+        );
+
+        final wallets = await database.select(database.walletTable).get();
+
+        expect(wallets.any((w) => w.label == 'New Wallet'), isTrue);
+      });
+    });
+
+    group('insertTransaction', () {
+      test('inserts transaction into database', () async {
+        await dataSource.insertTransaction(
+          TransactionTableCompanion.insert(
+            title: 'Test Transaction',
+            transactionDateTime: DateTime(2025, 12, 25),
+            amount: 100.0,
+            isIncome: true,
+            icon: '💵',
+            walletId: 1,
+          ),
+        );
+
+        final transactions = await database
+            .select(database.transactionTable)
+            .get();
+
+        expect(transactions.any((t) => t.title == 'Test Transaction'), isTrue);
+      });
+    });
+
+    group('saveSpendingChart', () {
+      test('saves spending chart to database', () async {
+        await dataSource.saveSpendingChart(
+          SpendingChartTableCompanion.insert(
+            spendingData: '[200.0, 300.0]',
+            totalAmount: '500.00',
+            percentageChange: '+15.0',
+          ),
+        );
+
+        final charts = await database.select(database.spendingChartTable).get();
+
+        expect(charts.any((c) => c.totalAmount == '500.00'), isTrue);
+      });
+    });
+  });
+}

--- a/test/features/dashboard/data/data_sources/dashboard_local_data_source_test.dart
+++ b/test/features/dashboard/data/data_sources/dashboard_local_data_source_test.dart
@@ -1,4 +1,5 @@
 import 'package:drift/native.dart';
+import 'package:extro/common/utils/transaction_type_icon.dart';
 import 'package:extro/core/database/app_database.dart';
 import 'package:extro/features/dashboard/data/data_sources/dashboard_local_data_source.dart';
 import 'package:flutter_test/flutter_test.dart' hide isNull, isNotNull;
@@ -86,7 +87,7 @@ void main() {
             label: 'New Wallet',
             balance: 500.0,
             currency: 'USD',
-            icon: '💳',
+            icon: TransactionTypeIcon.card.value,
             accentColor: '#FF0000',
           ),
         );
@@ -105,7 +106,7 @@ void main() {
             transactionDateTime: DateTime(2025, 12, 25),
             amount: 100.0,
             isIncome: true,
-            icon: '💵',
+            icon: TransactionTypeIcon.dollarSign.value,
             walletId: 1,
           ),
         );

--- a/test/features/dashboard/data/mappers/table_data_mappers_test.dart
+++ b/test/features/dashboard/data/mappers/table_data_mappers_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:extro/common/utils/transaction_type_icon.dart';
 import 'package:extro/core/database/app_database.dart';
 import 'package:extro/features/dashboard/data/mappers/table_data_mappers.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -13,7 +14,7 @@ void main() {
           label: 'Test Wallet',
           balance: 1000.0,
           currency: 'USD',
-          icon: '💳',
+          icon: 'card',
           accentColor: '#4A90E2',
         );
 
@@ -23,7 +24,7 @@ void main() {
         expect(wallet.label, equals('Test Wallet'));
         expect(wallet.balance, equals(1000.0));
         expect(wallet.currency, equals('USD'));
-        expect(wallet.icon, equals('💳'));
+        expect(wallet.icon, equals(TransactionTypeIcon.card.value));
         expect(wallet.accentColor, equals('#4A90E2'));
       });
     });
@@ -37,7 +38,7 @@ void main() {
           transactionDateTime: dateTime,
           amount: 3500.00,
           isIncome: true,
-          icon: '💵',
+          icon: 'dollar_sign',
           walletId: 1,
         );
 
@@ -48,7 +49,7 @@ void main() {
         expect(transaction.dateTime, equals(dateTime));
         expect(transaction.amount, equals(3500.00));
         expect(transaction.isIncome, equals(true));
-        expect(transaction.icon, equals('💵'));
+        expect(transaction.icon, equals(TransactionTypeIcon.dollarSign.value));
         expect(transaction.walletId, equals(1));
       });
 
@@ -59,7 +60,7 @@ void main() {
           transactionDateTime: DateTime(2025, 12, 24, 10, 30),
           amount: -85.50,
           isIncome: false,
-          icon: '🛒',
+          icon: 'cart',
           walletId: 1,
         );
 

--- a/test/features/dashboard/data/mappers/table_data_mappers_test.dart
+++ b/test/features/dashboard/data/mappers/table_data_mappers_test.dart
@@ -1,0 +1,108 @@
+import 'dart:convert';
+
+import 'package:extro/core/database/app_database.dart';
+import 'package:extro/features/dashboard/data/mappers/table_data_mappers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Table Data Mappers', () {
+    group('WalletTableDataMapper', () {
+      test('converts WalletTableData to Wallet domain entity', () {
+        const tableData = WalletTableData(
+          id: 1,
+          label: 'Test Wallet',
+          balance: 1000.0,
+          currency: 'USD',
+          icon: '💳',
+          accentColor: '#4A90E2',
+        );
+
+        final wallet = tableData.toDomain();
+
+        expect(wallet.id, equals(1));
+        expect(wallet.label, equals('Test Wallet'));
+        expect(wallet.balance, equals(1000.0));
+        expect(wallet.currency, equals('USD'));
+        expect(wallet.icon, equals('💳'));
+        expect(wallet.accentColor, equals('#4A90E2'));
+      });
+    });
+
+    group('TransactionTableDataMapper', () {
+      test('converts TransactionTableData to Transaction domain entity', () {
+        final dateTime = DateTime(2025, 12, 20, 9);
+        final tableData = TransactionTableData(
+          id: 1,
+          title: 'Salary',
+          transactionDateTime: dateTime,
+          amount: 3500.00,
+          isIncome: true,
+          icon: '💵',
+          walletId: 1,
+        );
+
+        final transaction = tableData.toDomain();
+
+        expect(transaction.id, equals(1));
+        expect(transaction.title, equals('Salary'));
+        expect(transaction.dateTime, equals(dateTime));
+        expect(transaction.amount, equals(3500.00));
+        expect(transaction.isIncome, equals(true));
+        expect(transaction.icon, equals('💵'));
+        expect(transaction.walletId, equals(1));
+      });
+
+      test('handles expense transactions correctly', () {
+        final tableData = TransactionTableData(
+          id: 2,
+          title: 'Grocery Shopping',
+          transactionDateTime: DateTime(2025, 12, 24, 10, 30),
+          amount: -85.50,
+          isIncome: false,
+          icon: '🛒',
+          walletId: 1,
+        );
+
+        final transaction = tableData.toDomain();
+
+        expect(transaction.amount, equals(-85.50));
+        expect(transaction.isIncome, equals(false));
+      });
+    });
+
+    group('SpendingChartTableDataMapper', () {
+      test(
+        'converts SpendingChartTableData to SpendingChart domain entity',
+        () {
+          final spendingData = [120.0, 85.0, 150.0, 95.0, 200.0, 175.0, 110.0];
+          final tableData = SpendingChartTableData(
+            id: 1,
+            spendingData: jsonEncode(spendingData),
+            totalAmount: '935.00',
+            percentageChange: '+12.5',
+          );
+
+          final spendingChart = tableData.toDomain();
+
+          expect(spendingChart.spendingData, equals(spendingData));
+          expect(spendingChart.totalAmount, equals('935.00'));
+          expect(spendingChart.percentageChange, equals('+12.5'));
+        },
+      );
+
+      test('handles empty spending data', () {
+        const tableData = SpendingChartTableData(
+          id: 1,
+          spendingData: '[]',
+          totalAmount: '0.00',
+          percentageChange: '0.0',
+        );
+
+        final spendingChart = tableData.toDomain();
+
+        expect(spendingChart.spendingData, isEmpty);
+        expect(spendingChart.totalAmount, equals('0.00'));
+      });
+    });
+  });
+}

--- a/test/features/dashboard/data/repositories/dashboard_stats_repository_test.dart
+++ b/test/features/dashboard/data/repositories/dashboard_stats_repository_test.dart
@@ -1,0 +1,84 @@
+import 'package:dartz/dartz.dart';
+import 'package:extro/core/failures/failure.dart';
+import 'package:extro/features/dashboard/data/data_sources/i_dashboard_local_data_source.dart';
+import 'package:extro/features/dashboard/data/repositories/dashboard_stats_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockIDashboardLocalDataSource extends Mock
+    implements IDashboardLocalDataSource {}
+
+void main() {
+  group('DashboardStatsRepository', () {
+    late MockIDashboardLocalDataSource mockDataSource;
+    late DashboardStatsRepository repository;
+
+    setUp(() {
+      mockDataSource = MockIDashboardLocalDataSource();
+      repository = DashboardStatsRepository(localDataSource: mockDataSource);
+    });
+
+    group('getDashboardStats', () {
+      test('returns stats with income and expenses', () async {
+        when(
+          () => mockDataSource.getTotalIncome(),
+        ).thenAnswer((_) async => 5550.0);
+        when(
+          () => mockDataSource.getTotalExpenses(),
+        ).thenAnswer((_) async => 326.49);
+
+        final result = await repository.getDashboardStats();
+
+        expect(result.isRight(), isTrue);
+        result.fold((failure) => fail('Should return Right'), (stats) {
+          expect(stats.totalIncome, equals(5550.0));
+          expect(stats.totalExpenses, equals(326.49));
+        });
+      });
+
+      test('returns zero stats when no transactions exist', () async {
+        when(
+          () => mockDataSource.getTotalIncome(),
+        ).thenAnswer((_) async => 0.0);
+        when(
+          () => mockDataSource.getTotalExpenses(),
+        ).thenAnswer((_) async => 0.0);
+
+        final result = await repository.getDashboardStats();
+
+        expect(result.isRight(), isTrue);
+        result.fold((failure) => fail('Should return Right'), (stats) {
+          expect(stats.totalIncome, equals(0.0));
+          expect(stats.totalExpenses, equals(0.0));
+        });
+      });
+
+      test('returns cache failure when data source throws exception', () async {
+        when(
+          () => mockDataSource.getTotalIncome(),
+        ).thenThrow(Exception('Database error'));
+
+        final result = await repository.getDashboardStats();
+
+        expect(result.isLeft(), isTrue);
+        result.fold(
+          (failure) => expect(failure, equals(const Failure.cache())),
+          (stats) => fail('Should return Left'),
+        );
+      });
+
+      test('handles expenses calculation error', () async {
+        when(
+          () => mockDataSource.getTotalIncome(),
+        ).thenAnswer((_) async => 1000.0);
+        when(
+          () => mockDataSource.getTotalExpenses(),
+        ).thenThrow(Exception('Calculation error'));
+
+        final result = await repository.getDashboardStats();
+
+        expect(result.isLeft(), isTrue);
+      });
+    });
+  });
+}

--- a/test/features/dashboard/data/repositories/dashboard_stats_repository_test.dart
+++ b/test/features/dashboard/data/repositories/dashboard_stats_repository_test.dart
@@ -1,4 +1,3 @@
-import 'package:dartz/dartz.dart';
 import 'package:extro/core/failures/failure.dart';
 import 'package:extro/features/dashboard/data/data_sources/i_dashboard_local_data_source.dart';
 import 'package:extro/features/dashboard/data/repositories/dashboard_stats_repository.dart';

--- a/test/features/dashboard/data/repositories/spending_chart_repository_test.dart
+++ b/test/features/dashboard/data/repositories/spending_chart_repository_test.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:dartz/dartz.dart';
 import 'package:extro/core/database/app_database.dart';
 import 'package:extro/core/failures/failure.dart';
 import 'package:extro/features/dashboard/data/data_sources/i_dashboard_local_data_source.dart';

--- a/test/features/dashboard/data/repositories/spending_chart_repository_test.dart
+++ b/test/features/dashboard/data/repositories/spending_chart_repository_test.dart
@@ -1,0 +1,97 @@
+import 'dart:convert';
+
+import 'package:dartz/dartz.dart';
+import 'package:extro/core/database/app_database.dart';
+import 'package:extro/core/failures/failure.dart';
+import 'package:extro/features/dashboard/data/data_sources/i_dashboard_local_data_source.dart';
+import 'package:extro/features/dashboard/data/repositories/spending_chart_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockIDashboardLocalDataSource extends Mock
+    implements IDashboardLocalDataSource {}
+
+void main() {
+  group('SpendingChartRepository', () {
+    late MockIDashboardLocalDataSource mockDataSource;
+    late SpendingChartRepository repository;
+
+    setUp(() {
+      mockDataSource = MockIDashboardLocalDataSource();
+      repository = SpendingChartRepository(localDataSource: mockDataSource);
+    });
+
+    group('getWeeklySpendingChart', () {
+      test('returns spending chart from data source', () async {
+        final spendingData = [120.0, 85.0, 150.0, 95.0, 200.0, 175.0, 110.0];
+        final chartTableData = SpendingChartTableData(
+          id: 1,
+          spendingData: jsonEncode(spendingData),
+          totalAmount: '935.00',
+          percentageChange: '+12.5',
+        );
+
+        when(
+          () => mockDataSource.getWeeklySpendingChart(),
+        ).thenAnswer((_) async => chartTableData);
+
+        final result = await repository.getWeeklySpendingChart();
+
+        expect(result.isRight(), isTrue);
+        result.fold((failure) => fail('Should return Right'), (chart) {
+          expect(chart.spendingData, equals(spendingData));
+          expect(chart.totalAmount, equals('935.00'));
+          expect(chart.percentageChange, equals('+12.5'));
+        });
+      });
+
+      test('returns default chart when data source returns null', () async {
+        when(
+          () => mockDataSource.getWeeklySpendingChart(),
+        ).thenAnswer((_) async => null);
+
+        final result = await repository.getWeeklySpendingChart();
+
+        expect(result.isRight(), isTrue);
+        result.fold((failure) => fail('Should return Right'), (chart) {
+          expect(chart.spendingData, isEmpty);
+          expect(chart.totalAmount, equals('0.00'));
+          expect(chart.percentageChange, equals('0.0'));
+        });
+      });
+
+      test('returns cache failure when data source throws exception', () async {
+        when(
+          () => mockDataSource.getWeeklySpendingChart(),
+        ).thenThrow(Exception('Database error'));
+
+        final result = await repository.getWeeklySpendingChart();
+
+        expect(result.isLeft(), isTrue);
+        result.fold(
+          (failure) => expect(failure, equals(const Failure.cache())),
+          (chart) => fail('Should return Left'),
+        );
+      });
+
+      test('handles empty spending data', () async {
+        final chartTableData = SpendingChartTableData(
+          id: 1,
+          spendingData: jsonEncode([]),
+          totalAmount: '0.00',
+          percentageChange: '0.0',
+        );
+
+        when(
+          () => mockDataSource.getWeeklySpendingChart(),
+        ).thenAnswer((_) async => chartTableData);
+
+        final result = await repository.getWeeklySpendingChart();
+
+        result.fold((failure) => fail('Should return Right'), (chart) {
+          expect(chart.spendingData, isEmpty);
+        });
+      });
+    });
+  });
+}

--- a/test/features/dashboard/data/repositories/transaction_repository_test.dart
+++ b/test/features/dashboard/data/repositories/transaction_repository_test.dart
@@ -1,4 +1,4 @@
-import 'package:dartz/dartz.dart';
+import 'package:extro/common/utils/transaction_type_icon.dart';
 import 'package:extro/core/database/app_database.dart';
 import 'package:extro/core/failures/failure.dart';
 import 'package:extro/features/dashboard/data/data_sources/i_dashboard_local_data_source.dart';
@@ -28,7 +28,7 @@ void main() {
             transactionDateTime: DateTime(2025, 12, 20, 9),
             amount: 3500.0,
             isIncome: true,
-            icon: '💵',
+            icon: TransactionTypeIcon.dollarSign.value,
             walletId: 1,
           ),
           TransactionTableData(
@@ -37,7 +37,7 @@ void main() {
             transactionDateTime: DateTime(2025, 12, 24, 10, 30),
             amount: -85.50,
             isIncome: false,
-            icon: '🛒',
+            icon: TransactionTypeIcon.cart.value,
             walletId: 1,
           ),
         ];
@@ -95,7 +95,7 @@ void main() {
             transactionDateTime: dateTime,
             amount: 100.0,
             isIncome: true,
-            icon: '💵',
+            icon: TransactionTypeIcon.dollarSign.value,
             walletId: 1,
           ),
         ];

--- a/test/features/dashboard/data/repositories/transaction_repository_test.dart
+++ b/test/features/dashboard/data/repositories/transaction_repository_test.dart
@@ -1,0 +1,115 @@
+import 'package:dartz/dartz.dart';
+import 'package:extro/core/database/app_database.dart';
+import 'package:extro/core/failures/failure.dart';
+import 'package:extro/features/dashboard/data/data_sources/i_dashboard_local_data_source.dart';
+import 'package:extro/features/dashboard/data/repositories/transaction_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockIDashboardLocalDataSource extends Mock
+    implements IDashboardLocalDataSource {}
+
+void main() {
+  group('TransactionRepository', () {
+    late MockIDashboardLocalDataSource mockDataSource;
+    late TransactionRepository repository;
+
+    setUp(() {
+      mockDataSource = MockIDashboardLocalDataSource();
+      repository = TransactionRepository(localDataSource: mockDataSource);
+    });
+
+    group('getRecentTransactions', () {
+      test('returns list of transactions from data source', () async {
+        final transactionTableData = [
+          TransactionTableData(
+            id: 1,
+            title: 'Salary',
+            transactionDateTime: DateTime(2025, 12, 20, 9),
+            amount: 3500.0,
+            isIncome: true,
+            icon: '💵',
+            walletId: 1,
+          ),
+          TransactionTableData(
+            id: 2,
+            title: 'Grocery Shopping',
+            transactionDateTime: DateTime(2025, 12, 24, 10, 30),
+            amount: -85.50,
+            isIncome: false,
+            icon: '🛒',
+            walletId: 1,
+          ),
+        ];
+
+        when(
+          () => mockDataSource.getRecentTransactions(),
+        ).thenAnswer((_) async => transactionTableData);
+
+        final result = await repository.getRecentTransactions();
+
+        expect(result.isRight(), isTrue);
+        result.fold((failure) => fail('Should return Right'), (transactions) {
+          expect(transactions.length, equals(2));
+          expect(transactions[0].title, equals('Salary'));
+          expect(transactions[0].isIncome, isTrue);
+          expect(transactions[1].title, equals('Grocery Shopping'));
+          expect(transactions[1].isIncome, isFalse);
+        });
+      });
+
+      test('returns empty list when no transactions exist', () async {
+        when(
+          () => mockDataSource.getRecentTransactions(),
+        ).thenAnswer((_) async => []);
+
+        final result = await repository.getRecentTransactions();
+
+        expect(result.isRight(), isTrue);
+        result.fold(
+          (failure) => fail('Should return Right'),
+          (transactions) => expect(transactions, isEmpty),
+        );
+      });
+
+      test('returns cache failure when data source throws exception', () async {
+        when(
+          () => mockDataSource.getRecentTransactions(),
+        ).thenThrow(Exception('Database error'));
+
+        final result = await repository.getRecentTransactions();
+
+        expect(result.isLeft(), isTrue);
+        result.fold(
+          (failure) => expect(failure, equals(const Failure.cache())),
+          (transactions) => fail('Should return Left'),
+        );
+      });
+
+      test('preserves transaction date and time', () async {
+        final dateTime = DateTime(2025, 12, 25, 14, 30);
+        final transactionTableData = [
+          TransactionTableData(
+            id: 1,
+            title: 'Test',
+            transactionDateTime: dateTime,
+            amount: 100.0,
+            isIncome: true,
+            icon: '💵',
+            walletId: 1,
+          ),
+        ];
+
+        when(
+          () => mockDataSource.getRecentTransactions(),
+        ).thenAnswer((_) async => transactionTableData);
+
+        final result = await repository.getRecentTransactions();
+
+        result.fold((failure) => fail('Should return Right'), (transactions) {
+          expect(transactions[0].dateTime, equals(dateTime));
+        });
+      });
+    });
+  });
+}

--- a/test/features/dashboard/data/repositories/wallet_repository_test.dart
+++ b/test/features/dashboard/data/repositories/wallet_repository_test.dart
@@ -1,4 +1,4 @@
-import 'package:dartz/dartz.dart';
+import 'package:extro/common/utils/transaction_type_icon.dart';
 import 'package:extro/core/database/app_database.dart';
 import 'package:extro/core/failures/failure.dart';
 import 'package:extro/features/dashboard/data/data_sources/i_dashboard_local_data_source.dart';
@@ -22,20 +22,20 @@ void main() {
     group('getAllWallets', () {
       test('returns list of wallets from data source', () async {
         final walletTableData = [
-          const WalletTableData(
+          WalletTableData(
             id: 1,
             label: 'Main Wallet',
             balance: 15000.0,
             currency: 'USD',
-            icon: '💳',
+            icon: TransactionTypeIcon.card.value,
             accentColor: '#4A90E2',
           ),
-          const WalletTableData(
+          WalletTableData(
             id: 2,
             label: 'Savings',
             balance: 8500.0,
             currency: 'USD',
-            icon: '💰',
+            icon: TransactionTypeIcon.coinsBag.value,
             accentColor: '#50C878',
           ),
         ];

--- a/test/features/dashboard/data/repositories/wallet_repository_test.dart
+++ b/test/features/dashboard/data/repositories/wallet_repository_test.dart
@@ -1,0 +1,85 @@
+import 'package:dartz/dartz.dart';
+import 'package:extro/core/database/app_database.dart';
+import 'package:extro/core/failures/failure.dart';
+import 'package:extro/features/dashboard/data/data_sources/i_dashboard_local_data_source.dart';
+import 'package:extro/features/dashboard/data/repositories/wallet_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockIDashboardLocalDataSource extends Mock
+    implements IDashboardLocalDataSource {}
+
+void main() {
+  group('WalletRepository', () {
+    late MockIDashboardLocalDataSource mockDataSource;
+    late WalletRepository repository;
+
+    setUp(() {
+      mockDataSource = MockIDashboardLocalDataSource();
+      repository = WalletRepository(localDataSource: mockDataSource);
+    });
+
+    group('getAllWallets', () {
+      test('returns list of wallets from data source', () async {
+        final walletTableData = [
+          const WalletTableData(
+            id: 1,
+            label: 'Main Wallet',
+            balance: 15000.0,
+            currency: 'USD',
+            icon: '💳',
+            accentColor: '#4A90E2',
+          ),
+          const WalletTableData(
+            id: 2,
+            label: 'Savings',
+            balance: 8500.0,
+            currency: 'USD',
+            icon: '💰',
+            accentColor: '#50C878',
+          ),
+        ];
+
+        when(
+          () => mockDataSource.getAllWallets(),
+        ).thenAnswer((_) async => walletTableData);
+
+        final result = await repository.getAllWallets();
+
+        expect(result.isRight(), isTrue);
+        result.fold((failure) => fail('Should return Right'), (wallets) {
+          expect(wallets.length, equals(2));
+          expect(wallets[0].label, equals('Main Wallet'));
+          expect(wallets[0].balance, equals(15000.0));
+          expect(wallets[1].label, equals('Savings'));
+        });
+      });
+
+      test('returns empty list when no wallets exist', () async {
+        when(() => mockDataSource.getAllWallets()).thenAnswer((_) async => []);
+
+        final result = await repository.getAllWallets();
+
+        expect(result.isRight(), isTrue);
+        result.fold(
+          (failure) => fail('Should return Right'),
+          (wallets) => expect(wallets, isEmpty),
+        );
+      });
+
+      test('returns cache failure when data source throws exception', () async {
+        when(
+          () => mockDataSource.getAllWallets(),
+        ).thenThrow(Exception('Database error'));
+
+        final result = await repository.getAllWallets();
+
+        expect(result.isLeft(), isTrue);
+        result.fold(
+          (failure) => expect(failure, equals(const Failure.cache())),
+          (wallets) => fail('Should return Left'),
+        );
+      });
+    });
+  });
+}

--- a/test/features/dashboard/domain/cubits/dashboard_stats_cubit_test.dart
+++ b/test/features/dashboard/domain/cubits/dashboard_stats_cubit_test.dart
@@ -1,0 +1,122 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dartz/dartz.dart';
+import 'package:extro/core/failures/failure.dart';
+import 'package:extro/features/dashboard/domain/cubits/dashboard_stats_cubit/dashboard_stats_cubit.dart';
+import 'package:extro/features/dashboard/domain/entities/dashboard_stats.dart';
+import 'package:extro/features/dashboard/domain/repositories/i_dashboard_stats_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockIDashboardStatsRepository extends Mock
+    implements IDashboardStatsRepository {}
+
+void main() {
+  group('DashboardStatsCubit', () {
+    late MockIDashboardStatsRepository mockRepository;
+
+    const testStats = DashboardStats(
+      totalIncome: 5550.0,
+      totalExpenses: 326.49,
+    );
+
+    setUp(() {
+      mockRepository = MockIDashboardStatsRepository();
+    });
+
+    group('Initial State', () {
+      test('initial state is DashboardStatsState.initial()', () {
+        final cubit = DashboardStatsCubit(repository: mockRepository);
+        expect(cubit.state, equals(const DashboardStatsState.initial()));
+      });
+    });
+
+    group('fetchDashboardStats', () {
+      blocTest<DashboardStatsCubit, DashboardStatsState>(
+        'emits [loading, success] when fetching stats succeeds',
+        build: () {
+          when(
+            () => mockRepository.getDashboardStats(),
+          ).thenAnswer((_) async => const Right(testStats));
+          return DashboardStatsCubit(repository: mockRepository);
+        },
+        act: (cubit) => cubit.fetchDashboardStats(),
+        expect: () => [
+          const DashboardStatsState.loading(),
+          const DashboardStatsState.success(testStats),
+        ],
+        verify: (_) {
+          verify(() => mockRepository.getDashboardStats()).called(1);
+        },
+      );
+
+      blocTest<DashboardStatsCubit, DashboardStatsState>(
+        'emits [loading, success] with zero stats',
+        build: () {
+          const zeroStats = DashboardStats(
+            totalIncome: 0.0,
+            totalExpenses: 0.0,
+          );
+          when(
+            () => mockRepository.getDashboardStats(),
+          ).thenAnswer((_) async => const Right(zeroStats));
+          return DashboardStatsCubit(repository: mockRepository);
+        },
+        act: (cubit) => cubit.fetchDashboardStats(),
+        expect: () => [
+          const DashboardStatsState.loading(),
+          const DashboardStatsState.success(
+            DashboardStats(totalIncome: 0.0, totalExpenses: 0.0),
+          ),
+        ],
+      );
+
+      blocTest<DashboardStatsCubit, DashboardStatsState>(
+        'emits [loading, failure] when fetching stats fails',
+        build: () {
+          when(
+            () => mockRepository.getDashboardStats(),
+          ).thenAnswer((_) async => const Left(Failure.cache()));
+          return DashboardStatsCubit(repository: mockRepository);
+        },
+        act: (cubit) => cubit.fetchDashboardStats(),
+        expect: () => [
+          const DashboardStatsState.loading(),
+          const DashboardStatsState.failure(Failure.cache()),
+        ],
+        verify: (_) {
+          verify(() => mockRepository.getDashboardStats()).called(1);
+        },
+      );
+
+      blocTest<DashboardStatsCubit, DashboardStatsState>(
+        'emits [loading, failure] with network error',
+        build: () {
+          when(
+            () => mockRepository.getDashboardStats(),
+          ).thenAnswer((_) async => const Left(Failure.network()));
+          return DashboardStatsCubit(repository: mockRepository);
+        },
+        act: (cubit) => cubit.fetchDashboardStats(),
+        expect: () => [
+          const DashboardStatsState.loading(),
+          const DashboardStatsState.failure(Failure.network()),
+        ],
+      );
+
+      blocTest<DashboardStatsCubit, DashboardStatsState>(
+        'does not emit new states when cubit is closed',
+        build: () {
+          when(
+            () => mockRepository.getDashboardStats(),
+          ).thenAnswer((_) async => const Right(testStats));
+          return DashboardStatsCubit(repository: mockRepository);
+        },
+        act: (cubit) async {
+          cubit.fetchDashboardStats();
+          await cubit.close();
+        },
+        expect: () => [const DashboardStatsState.loading()],
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary 
This pull request introduces local database layer using Drift for the dashboard feature, replacing hardcoded mock data with persistent storage. It includes new database tables, a seeder for initial dummy data, mappers for converting table data to domain entities, and updates to the data source and repository implementations. Dependency injection is also updated to provide the database instance throughout the app.

## Tests
- [x] Unit tests added/updated
